### PR TITLE
feat: do not depend on babel-polyfill

### DIFF
--- a/config/babel.js
+++ b/config/babel.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = {
+  plugins: [require.resolve('babel-plugin-transform-runtime')],
   presets: [require.resolve('babel-preset-es2015')]
 }

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const path = require('path')
 const webpackConfig = require('./webpack')
 const timeout = webpackConfig.timeout
 
@@ -26,7 +25,6 @@ module.exports = function (config) {
       }
     },
     files: [
-      path.join(require.resolve('babel-polyfill'), '/../../dist/polyfill.js'),
       'test/browser.js',
       'test/**/*.spec.js'
     ],

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -31,7 +31,6 @@ const specific = merge(custom1, custom2)
 
 const shared = {
   entry: [
-    require.resolve('babel-polyfill'),
     path.resolve('src/index.js')
   ],
   output: {
@@ -99,7 +98,7 @@ const shared = {
       test: /\.json$/,
       loader: 'json'
     }],
-    postLoaders: [{
+    preLoaders: [{
       test: /\.js$/,
       loader: 'transform?brfs'
     }]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "args-parser": "^1.0.2",
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",
-    "babel-polyfill": "^6.9.1",
+    "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "^6.9.0",
     "brfs": "^1.4.3",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Closes #36

BREAKING CHANGE:

This can break browser builds and tests and needs to be tested
carefully when upgrading.