### PR TITLE
Changelog generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ $ gulp build
 6. Commit the version change & `CHANGELOG.md`
 7. Create a git tag
 8. Run `git push` to `upstream/master`
+9. Publish a release to Github releases (if `GH_TOKEN` is available)
+10. Publish to npm
 
 ```bash
 # Major release

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ You can generate a changelog for all versions by using `--first`
 $ aegir-relase --first
 ```
 
+You can skip all changelog generation and the github release by passing
+in `--no-changelog`.
+
 ## Other Notes
 
 There is a badge.

--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ $ gulp build
 2. Run tests
 3. Build everything
 4. Bump the version in `package.json`
-5. Commit the version change
-6. Create a git tag
-7. Run `git push` to `upstream/master`
+5. Generate a changelog based on the git log
+6. Commit the version change & `CHANGELOG.md`
+7. Create a git tag
+8. Run `git push` to `upstream/master`
 
 ```bash
 # Major release
@@ -149,6 +150,12 @@ You can also specify a `--env` for a release, which can be either
 ```bash
 $ aegir-release --env node
 $ gulp release --env node
+```
+
+You can generate a changelog for all versions by using `--first`
+
+```bash
+$ aegir-relase --first
 ```
 
 ## Other Notes

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-es2015": "^6.9.0",
     "brfs": "^1.4.3",
     "chalk": "^1.1.3",
+    "conventional-github-releaser": "^1.1.3",
     "coveralls": "^2.11.12",
     "eslint": "^3.2.0",
     "eslint-config-standard": "^5.3.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-bump": "^2.2.0",
+    "gulp-conventional-changelog": "^1.1.0",
     "gulp-eslint": "^3.0.1",
     "gulp-filter": "^4.0.0",
     "gulp-git": "^1.10.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@
 
 const runSequence = require('run-sequence')
 const $ = require('gulp-load-plugins')()
+const fs = require('fs')
 
 // Workaround gulp not exiting if there are some
 // resources not freed
@@ -33,4 +34,8 @@ exports.hooksRun = (gulp, name, tasks, done) => {
 exports.fail = (msg) => {
   $.util.log($.util.colors.red(msg))
   process.exit(1)
+}
+
+exports.getVersion = () => {
+  return JSON.parse(fs.readFileSync('./package.json', 'utf8')).version
 }

--- a/tasks/release/bump.js
+++ b/tasks/release/bump.js
@@ -2,8 +2,9 @@
 
 const $ = require('gulp-load-plugins')()
 const semver = require('semver')
-const fs = require('fs')
 const _ = require('lodash')
+
+const getVersion = require('../../src/utils').getVersion
 
 function getType () {
   if (_.includes($.util.env._, 'major')) return 'major'
@@ -13,21 +14,13 @@ function getType () {
   return 'patch'
 }
 
-function getCurrentVersion () {
-  return JSON.parse(fs.readFileSync('./package.json', 'utf8')).version
-}
-
 module.exports = (gulp, done) => {
   const type = getType()
-  const newVersion = semver.inc(getCurrentVersion(), type)
+  const newVersion = semver.inc(getVersion(), type)
 
   $.util.log('Releasing %s', newVersion)
 
   return gulp.src('./package.json')
     .pipe($.bump({version: newVersion}))
     .pipe(gulp.dest('./'))
-    .pipe($.git.add())
-    .pipe($.git.commit(`chore: release version v${newVersion}`, {args: '-n'}))
-    .pipe($.filter('package.json'))
-    .pipe($.tagVersion())
 }

--- a/tasks/release/changelog.js
+++ b/tasks/release/changelog.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const $ = require('gulp-load-plugins')()
+
+module.exports = (gulp, done) => {
+  const releaseCount = $.util.env.first ? 0 : 1
+
+  return gulp.src('CHANGELOG.md')
+    .pipe($.conventionalChangelog({
+      preset: 'angular',
+      releaseCount
+    }))
+    .pipe(gulp.dest('./'))
+}

--- a/tasks/release/changelog.js
+++ b/tasks/release/changelog.js
@@ -3,6 +3,11 @@
 const $ = require('gulp-load-plugins')()
 
 module.exports = (gulp, done) => {
+  if ($.util.env.changelog === false) {
+    $.util.log('Skipping changelog generation')
+    return done()
+  }
+
   const releaseCount = $.util.env.first ? 0 : 1
 
   return gulp.src('CHANGELOG.md')

--- a/tasks/release/commit.js
+++ b/tasks/release/commit.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const $ = require('gulp-load-plugins')()
+
+const getVersion = require('../../src/utils').getVersion
+
+module.exports = (gulp, done) => {
+  const newVersion = getVersion()
+
+  return gulp.src(['package.json', 'CHANGELOG.md'])
+    .pipe($.git.add())
+    .pipe($.git.commit(`chore: release version v${newVersion}`, {args: '-n'}))
+    .pipe($.filter('package.json'))
+    .pipe($.tagVersion())
+}

--- a/tasks/release/github.js
+++ b/tasks/release/github.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const $ = require('gulp-load-plugins')()
+const conventionalGithubReleaser = require('conventional-github-releaser')
+
+module.exports = (gulp, done) => {
+  const token = process.env.GH_TOKEN || $.util.env.token
+
+  if (!token) {
+    $.util.log($.util.colors.yellow(`
+Skipping Github release as you are missing an oauth token.
+You can supply one by either using $GH_TOKEN or --token.
+    `))
+    return done()
+  }
+
+  conventionalGithubReleaser({
+    type: 'oauth',
+    token
+  }, {
+    preset: 'angular'
+  }, done)
+}

--- a/tasks/release/github.js
+++ b/tasks/release/github.js
@@ -4,6 +4,11 @@ const $ = require('gulp-load-plugins')()
 const conventionalGithubReleaser = require('conventional-github-releaser')
 
 module.exports = (gulp, done) => {
+  if ($.util.env.changelog === false) {
+    $.util.log('Skipping github release')
+    return done()
+  }
+
   const token = process.env.GH_TOKEN || $.util.env.token
 
   if (!token) {

--- a/tasks/release/post-build.js
+++ b/tasks/release/post-build.js
@@ -9,6 +9,7 @@ module.exports = (gulp, done) => {
     'release:changelog',
     'release:commit',
     'release:push',
+    'release:github',
     'release:publish',
     done
   )

--- a/tasks/release/post-build.js
+++ b/tasks/release/post-build.js
@@ -6,6 +6,8 @@ module.exports = (gulp, done) => {
   runSequence.use(gulp)(
     'release:contributors',
     'release:bump',
+    'release:changelog',
+    'release:commit',
     'release:push',
     'release:publish',
     done


### PR DESCRIPTION
As discussed in #30 this adds the first round of functionality to `aegir-release` to give us a base level of things.

- Generate `CHANGELOG.md` based on git log following the proposed commit message convention
- Generate a github release on the same basics
- The ability to skip this process by using `--no-changelog`
