### PR TITLE
feat(webpack): enable dedupe plugin

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -116,7 +116,8 @@ const shared = {
   },
   timeout: 80000,
   plugins: [
-    new webpack.DefinePlugin({'fs.writeSync': false})
+    new webpack.DefinePlugin({'fs.writeSync': false}),
+    new webpack.optimize.DedupePlugin()
   ]
 }
 


### PR DESCRIPTION
Make js-ipfs a lot smaller. Ref https://github.com/ipfs/js-ipfs/issues/398