### PR TITLE
Add a way to disable PhantomJS testing

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -12,7 +12,7 @@ if (process.env.TRAVIS) {
   browsers.push('Chrome')
 }
 
-if (!process.env.DEBUG) {
+if (!process.env.DEBUG || process.env.PHANTOM !== 'off') {
   browsers.push('PhantomJS')
 }
 

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -12,7 +12,7 @@ if (process.env.TRAVIS) {
   browsers.push('Chrome')
 }
 
-if (!process.env.DEBUG || process.env.PHANTOM !== 'off') {
+if (!process.env.DEBUG && process.env.PHANTOM !== 'off') {
   browsers.push('PhantomJS')
 }
 


### PR DESCRIPTION
Because: https://github.com/ipfs/js-ipfs-unixfs-engine/pull/64#issuecomment-245770818
related: https://github.com/dignifiedquire/aegir/issues/48
