### PR TITLE
Add possibility to specify entry file for webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For example
 
 ```js
 // awesome-tests module
-const loadFixture = require('aegir/fixtures'
+const loadFixture = require('aegir/fixtures')
 
 const myFixture = loadFixture(__dirname, 'fixtures/coolfixture', 'awesome-tests')
 ```
@@ -168,6 +168,20 @@ $ aegir-build
 # or as gulp task
 $ gulp build
 ```
+
+**Specifying a custom entry file for Webpack**
+
+By default, `aegir` uses `src/index.js` as the entry file for Webpack. You can customize which file to use as the entry point by specifying `entry` field in your user configuration file. To do this, create `.aegir.js` file in your project's root diretory and add point the `entry` field to the file Webpack should use as the entry:
+
+```javascript
+module.exports = {
+  entry: "src/browser-index.js",
+}
+```
+
+Webpack will use the specified file as the entry point and output it to `dist/<filename>`, eg. `dist/browser-index.js`.
+
+If `.aegir.js` file is not present in the project, webpack will use `src/index.js` as the default entry file.
 
 ### Releasing
 

--- a/config/user.js
+++ b/config/user.js
@@ -12,5 +12,6 @@ try {
 module.exports = {
   pkg: pkg,
   customPkg: pkg.aegir || {},
-  customConfig: customConfig || {}
+  customConfig: customConfig || {},
+  entry: customConfig.entry || 'src/index.js'
 }

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -10,13 +10,14 @@ let user = require('./user')
 // e.g. peer-id -> PeerId
 const libraryName = upperFirst(camelCase(user.pkg.name))
 const specific = merge(user.customPkg || {}, user.customPkg || {})
+const entry = user.entry || 'src/index.js'
 
 const shared = {
   entry: [
-    path.resolve('src/index.js')
+    path.resolve(entry)
   ],
   output: {
-    filename: 'index.js',
+    filename: entry.split('/').pop(),
     library: libraryName,
     path: 'dist'
   },

--- a/tasks/build/browser.js
+++ b/tasks/build/browser.js
@@ -13,7 +13,6 @@ module.exports = (gulp) => {
     const config = require('../../config/webpack')
 
     const c = config
-    c.output.filename = 'index.js'
     c.devtool = 'source-map'
     c.plugins.push(
       new webpack.optimize.DedupePlugin()
@@ -21,7 +20,7 @@ module.exports = (gulp) => {
 
     webpack(c, webpackDone(() => {
       pump([
-        gulp.src('dist/index.js'),
+        gulp.src('dist/' + c.output.filename),
         minifier({
           mangle: false
         }, uglify),

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -1,19 +1,36 @@
 'use strict'
 
+const path = require('path')
+
+let sourceDirectories = [
+  '*.js',
+  'bin/**',
+  'config/**/*.js',
+  'test/**/*.js',
+  'src/**/*.js',
+  'tasks/**/*.js',
+  'examples/**/*.js',
+  'benchmarks/**/*.js'
+]
+
+// Get custom entry file's directory and add it to the source directories
+try {
+  const customConfig = require(path.resolve('.aegir.js'))
+  if (customConfig.entry) {
+    // Get the entry file path and remove the filename from it
+    const entryDir = customConfig.entry.split('/').slice(0, -1).join('/')
+    if (entryDir !== '') {
+      sourceDirectories.push(entryDir + '/**/*.js')
+    }
+  }
+} catch (err) {
+}
+
 module.exports = (gulp) => {
   gulp.task('lint', () => {
     const eslint = require('gulp-eslint')
 
-    return gulp.src([
-      '*.js',
-      'bin/**',
-      'config/**/*.js',
-      'test/**/*.js',
-      'src/**/*.js',
-      'tasks/**/*.js',
-      'examples/**/*.js',
-      'benchmarks/**/*.js'
-    ])
+    return gulp.src(sourceDirectories)
       .pipe(eslint(`${__dirname}/../config/eslintrc.yml`))
       .pipe(eslint.format())
       .pipe(eslint.failAfterError())


### PR DESCRIPTION
This PR will make it possible to specify the entry file for webpack.

The entry file is specified in `.aegir.js.` with field `entry`. Users of aegir will need to add `.aegir.js` file to their project's root directory and specify the entry point, eg:

```javascript
module.exports = {
  entry: "src/browser-index.js",
}
```

Webpack will use the specified file as the entry point and output it to `dist/<filename>`, eg. `dist/browser-index.js`.

If `.aegir.js` file is present in the project, webpack will use `src/index.js` as the default entry file.