### PR TITLE
coverage: add codecov to coverage providers and allow to select it

### DIFF
--- a/bin/coverage
+++ b/bin/coverage
@@ -4,6 +4,7 @@
 
 const gulp = require('gulp')
 const coveralls = require('coveralls')
+const codecov = require('codecov/lib/codecov').upload
 const fs = require('fs')
 const path = require('path')
 const args = require('args-parser')(process.argv)
@@ -11,16 +12,37 @@ const args = require('args-parser')(process.argv)
 require('../src/gulp-log')(gulp)
 require('../gulp')(gulp, ['coverage'])
 
-if (args.publish) {
-  // ./node_modules/.bin/coveralls --verbose < coverage/lcov.info
-  const input = fs.readFileSync(path.join(process.cwd(), 'coverage', 'lcov.info'))
-  coveralls.handleInput(input.toString(), (err) => {
-    if (err) {
-      throw err
-    }
+const handlers = {
+  coveralls: (coverFile) => {
+    const input = fs.readFileSync(coverFile)
+    coveralls.handleInput(input.toString(), (err) => {
+      if (err) {
+        throw err
+      }
 
-    console.log('Finished uploading coveralls report')
-  })
+      console.log('Finished uploading coveralls report')
+  // ./node_modules/.bin/coveralls --verbose < coverage/lcov.info
+    })
+  },
+  codecov: (coverFile) => {
+    codecov({options: {
+      file: coverFile,
+      disable: 'search'
+    }})
+  }
+}
+
+if (args.publish) {
+  const provider = args.provider || 'coveralls'
+  const handler = handlers[provider]
+  if (handler === undefined) {
+    const msg = 'no such coverage report provider: ' + provider
+    console.log(msg)
+    throw new Error(msg)
+  }
+
+  const coverFile = path.join(process.cwd(), 'coverage', 'lcov.info')
+  handler(coverFile)
 } else {
   gulp.start('coverage')
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "args-parser": "^1.0.2",
     "chalk": "^1.1.3",
     "clean-documentation-theme": "^0.4.2",
+    "codecov": "^1.0.1",
     "conventional-github-releaser": "^1.1.3",
     "coveralls": "^2.11.15",
     "detect-node": "^2.0.3",


### PR DESCRIPTION
Coveralls is the default, you can select codecov in your package.json
file by adding `--provider=codecov` to the `coverage-publish` script.