### PR TITLE
POC: Add support to run tests in web workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-<a name="9.3.4"></a>
-## [9.3.4](https://github.com/dignifiedquire/aegir/compare/v9.3.3...v9.3.4) (2017-01-23)
-
-
-
 <a name="9.3.3"></a>
 ## [9.3.3](https://github.com/dignifiedquire/aegir/compare/v9.3.2...v9.3.3) (2017-01-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="9.3.4"></a>
+## [9.3.4](https://github.com/dignifiedquire/aegir/compare/v9.3.3...v9.3.4) (2017-01-23)
+
+
+
 <a name="9.3.3"></a>
 ## [9.3.3](https://github.com/dignifiedquire/aegir/compare/v9.3.2...v9.3.3) (2017-01-21)
 

--- a/bin/test
+++ b/bin/test
@@ -10,6 +10,8 @@ require('../gulp')(gulp, ['test'])
 
 if (args.browser) {
   gulp.start('test:browser')
+} else if (args.webworker) {
+  gulp.start('test:webworker')
 } else if (args.node) {
   gulp.start('test:node')
 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aegir",
-  "version": "9.3.4",
+  "version": "9.3.3",
   "description": "JavaScript project management",
   "main": "index.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-own-reporter": "^1.1.2",
+    "karma-mocha-webworker": "^1.3.0",
     "karma-sauce-launcher": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aegir",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "JavaScript project management",
   "main": "index.js",
   "browser": {

--- a/tasks/release/browser.js
+++ b/tasks/release/browser.js
@@ -7,6 +7,7 @@ module.exports = (gulp) => {
     runSequence.use(gulp)(
       'lint',
       'test:browser',
+      'test:webworker',
       done
     )
   })

--- a/tasks/test/browser.js
+++ b/tasks/test/browser.js
@@ -11,8 +11,9 @@ module.exports = (gulp) => {
     const sauce = process.env.SAUCE_USERNAME && process.env.TRAVIS
 
     new Server({
-      configFile: path.join(__dirname, webWorker ?
-        '../../config/karma.webworker.conf.js' : '../../config/karma.conf.js'),
+      configFile: path.join(__dirname, webWorker
+        ? '../../config/karma.webworker.conf.js'
+        : '../../config/karma.conf.js'),
       singleRun: !debug
     }, (code) => {
       if (sauce) {

--- a/tasks/test/browser.js
+++ b/tasks/test/browser.js
@@ -11,7 +11,8 @@ module.exports = (gulp) => {
     const sauce = process.env.SAUCE_USERNAME && process.env.TRAVIS
 
     new Server({
-      configFile: path.join(__dirname, '../../config/karma.conf.js'),
+      configFile: path.join(__dirname, webWorker ?
+        '../../config/karma.webworker.conf.js' : '../../config/karma.conf.js'),
       singleRun: !debug
     }, (code) => {
       if (sauce) {
@@ -23,6 +24,12 @@ module.exports = (gulp) => {
   })
 
   gulp.task('test:browser', (done) => {
+    utils.hooksRun(gulp, 'test:browser', ['karma'], utils.exitOnFail(done))
+  })
+
+  let webWorker = false
+  gulp.task('test:webworker', (done) => {
+    webWorker = true
     utils.hooksRun(gulp, 'test:browser', ['karma'], utils.exitOnFail(done))
   })
 }


### PR DESCRIPTION
This is a POC to add support for running tests in webworkers. I'm using this karma plugin - https://github.com/Joris-van-der-Wel/karma-mocha-webworker, it seems to get the job done and it allows running _all_ tests inside a webworker. @dignifiedquire @diasdavid please let me know what you think.